### PR TITLE
Проверка проблемы с отправкой сообщений

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
         const messageDiv = document.createElement('div');
-        const isSent = data.sender_id === {{ current_user.id }};
+        const isSent = data.sender_id === window.currentUserId;
         messageDiv.className = 'message ' + (isSent ? 'sent' : 'received');
         messageDiv.setAttribute('data-message-id', data.message_id || 'new-' + Date.now());
         messageDiv.innerHTML = `<strong>${data.sender}</strong>: ${data.message} <br><small>${new Date(data.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} <span class="status">✓✓</span></small>`;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -10,6 +10,11 @@
 {% block head %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <script src="{{ url_for('static', filename='js/socket.io.min.js') }}"></script>
+    <script>
+        // Передаем ID текущего пользователя в глобальную переменную, чтобы к ней мог обратиться статический script.js
+        // @ts-ignore
+        window.currentUserId = {{ current_user.id }};
+    </script>
     <script src="{{ url_for('static', filename='js/script.js') }}?v={{ 'now'|timestamp }}"></script>
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
Fix message sending by correctly passing user ID to client-side script.

The `{{ current_user.id }}` Jinja variable was incorrectly used in `static/js/script.js`, which is not processed by the Jinja templating engine. This resulted in a client-side JavaScript syntax error, preventing the message sending functionality from working. The fix involves passing `current_user.id` via an inline script in `chat.html` to a global JavaScript variable, which `script.js` then uses.