### PR TITLE
Fix page reload on message send

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -25,7 +25,8 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
         const messageDiv = document.createElement('div');
-        const isSent = data.sender_id === {{ current_user.id }};
+        const currentUserId = parseInt(document.body.getAttribute('data-user-id'));
+        const isSent = currentUserId && data.sender_id === currentUserId;
         messageDiv.className = 'message ' + (isSent ? 'sent' : 'received');
         messageDiv.setAttribute('data-message-id', data.message_id || 'new-' + Date.now());
         messageDiv.innerHTML = `<strong>${data.sender}</strong>: ${data.message} <br><small>${new Date(data.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} <span class="status">✓✓</span></small>`;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ 'now'|timestamp }}">
     {% block head %}{% endblock %}
 </head>
-<body>
+<body data-user-id="{{ current_user.id if current_user.is_authenticated else '' }}">
     {% block content %}{% endblock %}
     <footer>
         <div class="menu">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Pass user ID via `data-user-id` attribute to fix JavaScript error in static file and prevent page reload.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The page reloaded on message submission because `static/js/script.js` contained a Jinja expression `{{ current_user.id }}`. As `script.js` is served statically, Jinja did not process it, leading to a raw string in the JavaScript code. This broke the script, preventing the form submission from being intercepted and causing a full page reload.